### PR TITLE
fix(chat): default home-screen name to "Lingo Chat"

### DIFF
--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -4,7 +4,9 @@ import ChatInterface from '@/components/Chat/ChatInterface';
 import ChatSignInGate from '@/components/Chat/ChatSignInGate';
 
 export const metadata: Metadata = {
-  title: 'English Practice Chat | Studio Lingo',
+  // Kept short on purpose: iOS "Add to Home Screen" pre-fills the app name
+  // from the page <title>, so this is what students see as the default name.
+  title: 'Lingo Chat',
   description:
     'Practice your English with an AI native speaker. Chat, speak, and improve — powered by Studio Lingo.',
   // PWA: lets the chat install as a standalone "Lingo Chat" app.


### PR DESCRIPTION
## Summary
- iOS "Add to Home Screen" pre-fills the app name from the page `<title>`, which was the long "English Practice Chat | Studio Lingo".
- Shortens the `/chat` page title to **"Lingo Chat"**, so the suggested home-screen name matches the manifest name and Apple web-app title.
- One-line change to `src/app/chat/page.tsx`.

## Verified locally
- `<title>Lingo Chat</title>` and `apple-mobile-web-app-title="Lingo Chat"` on /chat.
- tsc passes.

## Test plan
- [ ] iPhone: re-add /chat to Home Screen → suggested name is "Lingo Chat".
- [ ] Existing chat behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)