### PR TITLE
fix(chat): Android PWA install with logo (service worker)

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,18 @@
+// Minimal service worker — its only job is to make the site installable as a
+// real PWA on Android. Chrome requires a registered service worker that has a
+// fetch handler before it will create a true home-screen app (WebAPK) with the
+// manifest icon; without one it only makes a generic bookmark shortcut.
+//
+// It deliberately does NOT cache anything: every request goes straight to the
+// network, so the chat always loads fresh and there is no stale-content risk.
+self.addEventListener('install', () => self.skipWaiting());
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('fetch', () => {
+  // No-op: let the browser handle every request normally (network).
+  // The mere presence of this fetch handler is what satisfies Chrome's
+  // installability check.
+});

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from 'next';
 import { SignedIn, SignedOut } from '@clerk/nextjs';
 import ChatInterface from '@/components/Chat/ChatInterface';
 import ChatSignInGate from '@/components/Chat/ChatSignInGate';
+import ServiceWorkerRegister from '@/components/Chat/ServiceWorkerRegister';
 
 export const metadata: Metadata = {
   // Kept short on purpose: iOS "Add to Home Screen" pre-fills the app name
@@ -34,6 +35,7 @@ export const viewport: Viewport = {
 export default function ChatPage() {
   return (
     <>
+      <ServiceWorkerRegister />
       <SignedIn>
         <ChatInterface />
       </SignedIn>

--- a/src/components/Chat/ServiceWorkerRegister.tsx
+++ b/src/components/Chat/ServiceWorkerRegister.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useEffect } from 'react';
+
+/**
+ * Registers the minimal service worker (/sw.js) so Android Chrome treats the
+ * chat as an installable PWA and creates a real home-screen app with the
+ * manifest icon (instead of a generic bookmark shortcut). Renders nothing.
+ *
+ * Registration failures are swallowed — they must never affect the chat
+ * itself; the worst case is simply falling back to the old shortcut behavior.
+ */
+export default function ServiceWorkerRegister() {
+  useEffect(() => {
+    if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) {
+      return;
+    }
+    const register = () => {
+      navigator.serviceWorker.register('/sw.js').catch(() => {
+        /* non-fatal */
+      });
+    };
+    if (document.readyState === 'complete') {
+      register();
+    } else {
+      window.addEventListener('load', register, { once: true });
+      return () => window.removeEventListener('load', register);
+    }
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- On Android, "Add to Home Screen" created a generic **bookmark shortcut** (gray icon + Chrome badge) instead of a real app with the logo.
- Cause: Android Chrome only builds a real installable app (WebAPK, using the manifest icon) when a **service worker** is registered. We had none.
- Adds a minimal no-op service worker (`public/sw.js`) and registers it from `/chat` via a small client component. It caches nothing, so the chat always loads fresh — no stale-content risk.
- iOS already worked (apple-touch-icon) and is unaffected.

## Verified locally
- `/sw.js` serves as `application/javascript` and has a fetch handler.
- tsc passes.

## Test plan (Android Chrome, after deploy)
- [ ] Delete the old gray shortcut.
- [ ] Open studiolingo.ge/chat, reload once, then Chrome menu → **Install app** (should now appear).
- [ ] Icon on home screen shows the Lingo Chat logo, no Chrome badge, opens standalone.
- [ ] iOS still installs with logo + name "Lingo Chat".

🤖 Generated with [Claude Code](https://claude.com/claude-code)