### PR TITLE
fix(chat): iOS voice via Whisper + symmetric level grid

### DIFF
--- a/src/app/api/transcribe/route.ts
+++ b/src/app/api/transcribe/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from "next/server";
+
+// Allow up to 30s for transcription (short voice clips usually return in <3s).
+export const maxDuration = 30;
+
+// Speech-to-text for the chat's voice input. Used by iPhone/iPad, where the
+// browser Web Speech API is unreliable inside standalone PWAs. The client
+// records a short audio clip and posts it here; we forward it to OpenAI Whisper
+// (same OPENAI_API_KEY already used by /api/tts) and return the transcript.
+export async function POST(req: NextRequest) {
+  const apiKey = process.env.OPENAI_API_KEY;
+
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: "OPENAI_API_KEY not configured" },
+      { status: 503 },
+    );
+  }
+
+  try {
+    const form = await req.formData();
+    const file = form.get("file");
+
+    if (!(file instanceof Blob)) {
+      return NextResponse.json({ error: "Missing audio file" }, { status: 400 });
+    }
+
+    const filename =
+      file instanceof File && file.name ? file.name : "recording.mp4";
+
+    const upstream = new FormData();
+    upstream.append("file", file, filename);
+    upstream.append("model", "whisper-1");
+    // Students are practicing English — hinting the language improves accuracy.
+    upstream.append("language", "en");
+    upstream.append("response_format", "json");
+
+    const response = await fetch(
+      "https://api.openai.com/v1/audio/transcriptions",
+      {
+        method: "POST",
+        headers: { Authorization: `Bearer ${apiKey}` },
+        body: upstream,
+      },
+    );
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      console.error("OpenAI transcription error:", response.status, errorText);
+      return NextResponse.json(
+        { error: `Transcription failed: ${response.status}` },
+        { status: response.status },
+      );
+    }
+
+    const data = await response.json();
+    return NextResponse.json({ text: typeof data.text === "string" ? data.text : "" });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : "Unknown error";
+    console.error("Transcribe route error:", msg);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/components/Chat/ChatInterface.tsx
+++ b/src/components/Chat/ChatInterface.tsx
@@ -110,6 +110,14 @@ const LEVEL_BADGE: Record<Level, string> = {
   A1: 'Be', A2: 'El', B1: 'In', B2: 'Up', C1: 'Ad', C2: 'Pr',
 };
 
+// True on iPhone / iPad. Voice input is routed to record-and-transcribe on
+// Apple mobile because the Web Speech API is unreliable in iOS standalone PWAs
+// (the first attempt is swallowed and transcribes nothing).
+const isAppleMobile = () =>
+  typeof navigator !== 'undefined' &&
+  (/iP(hone|ad|od)/.test(navigator.userAgent) ||
+    (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1));
+
 const pickBestVoice = (voices: SpeechSynthesisVoice[]): SpeechSynthesisVoice | undefined => {
   const ua = typeof navigator !== 'undefined' ? navigator.userAgent : '';
   const isIOS = /iPad|iPhone|iPod/.test(ua);
@@ -172,6 +180,7 @@ export default function ChatInterface() {
   const [isLoading, setIsLoading] = useState(false);
   const [isStarting, setIsStarting] = useState(false);
   const [isRecording, setIsRecording] = useState(false);
+  const [isTranscribing, setIsTranscribing] = useState(false);
   const [playingId, setPlayingId] = useState<string | null>(null);
   const [speakerMode, setSpeakerMode] = useState(false);
 
@@ -190,6 +199,11 @@ export default function ChatInterface() {
   const isRecordingRef = useRef(false);
   // v5: on iOS we accumulate final text across fresh sub-sessions
   const accumulatedRef = useRef('');
+  // iOS record-and-transcribe path (see startRecordingIOS).
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const mediaStreamRef = useRef<MediaStream | null>(null);
+  const audioChunksRef = useRef<Blob[]>([]);
+  const iosRecordActiveRef = useRef(false);
   const inputRef = useRef<HTMLDivElement>(null);
 
   // The chat input is a contentEditable <div> (not an <input>) so that mobile
@@ -860,13 +874,114 @@ export default function ChatInterface() {
     }
   }, [input]);
 
-  const handleVoiceInput = useCallback(() => {
-    if (isRecording) {
-      stopRecording();
-    } else {
-      startRecording();
+  // ── iOS voice input: record + server transcription (Whisper) ────────────────
+  // The Web Speech API does not work reliably inside iOS standalone PWAs, so on
+  // iPhone/iPad we record a short clip with MediaRecorder and transcribe it via
+  // /api/transcribe. Non-iOS platforms keep the live Web Speech path unchanged.
+  const startRecordingIOS = useCallback(async () => {
+    stopSpeaking(); // don't let TTS playback leak into the mic
+
+    iosRecordActiveRef.current = true;
+    setIsRecording(true);
+
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      // User may have tapped stop before the mic became ready.
+      if (!iosRecordActiveRef.current) {
+        stream.getTracks().forEach((t) => t.stop());
+        return;
+      }
+      mediaStreamRef.current = stream;
+      audioChunksRef.current = [];
+
+      const recorder = new MediaRecorder(stream);
+      mediaRecorderRef.current = recorder;
+
+      recorder.ondataavailable = (e) => {
+        if (e.data && e.data.size > 0) audioChunksRef.current.push(e.data);
+      };
+
+      recorder.onstop = async () => {
+        mediaStreamRef.current?.getTracks().forEach((t) => t.stop());
+        mediaStreamRef.current = null;
+
+        const mimeType = recorder.mimeType || 'audio/mp4';
+        const blob = new Blob(audioChunksRef.current, { type: mimeType });
+        audioChunksRef.current = [];
+        mediaRecorderRef.current = null;
+
+        if (blob.size === 0) return; // nothing captured (e.g. instant stop)
+
+        setIsTranscribing(true);
+        try {
+          const ext = mimeType.includes('webm')
+            ? 'webm'
+            : mimeType.includes('ogg')
+              ? 'ogg'
+              : mimeType.includes('wav')
+                ? 'wav'
+                : 'mp4';
+          const form = new FormData();
+          form.append('file', blob, `recording.${ext}`);
+          const res = await fetch('/api/transcribe', { method: 'POST', body: form });
+          if (res.ok) {
+            const data = await res.json();
+            const text = (data.text || '').trim();
+            if (text) {
+              const prefix = input.trim() ? input.trim() + ' ' : '';
+              writeInput(prefix + text);
+            }
+          }
+        } catch {
+          /* transcription failed — leave input as-is, never crash the chat */
+        } finally {
+          setIsTranscribing(false);
+        }
+      };
+
+      recorder.start();
+    } catch {
+      // Permission denied or mic unavailable.
+      iosRecordActiveRef.current = false;
+      mediaStreamRef.current = null;
+      setIsRecording(false);
     }
-  }, [isRecording, startRecording, stopRecording]);
+  }, [input, writeInput, stopSpeaking]);
+
+  const stopRecordingIOS = useCallback(() => {
+    iosRecordActiveRef.current = false;
+    setIsRecording(false);
+    const recorder = mediaRecorderRef.current;
+    if (recorder && recorder.state !== 'inactive') {
+      try { recorder.stop(); } catch { /* noop */ }
+    } else if (mediaStreamRef.current) {
+      // Recorder not started yet — release the stream we acquired.
+      mediaStreamRef.current.getTracks().forEach((t) => t.stop());
+      mediaStreamRef.current = null;
+    }
+  }, []);
+
+  const handleVoiceInput = useCallback(() => {
+    if (isTranscribing) return; // busy transcribing the previous clip
+    const useIOSPath =
+      isAppleMobile() &&
+      typeof MediaRecorder !== 'undefined' &&
+      !!navigator.mediaDevices?.getUserMedia;
+    if (useIOSPath) {
+      if (isRecording) stopRecordingIOS();
+      else startRecordingIOS();
+    } else {
+      if (isRecording) stopRecording();
+      else startRecording();
+    }
+  }, [
+    isRecording,
+    isTranscribing,
+    startRecording,
+    stopRecording,
+    startRecordingIOS,
+    stopRecordingIOS,
+  ]);
 
   // ── Speaker mode toggle ────────────────────────────────────────────────────
   // When turning ON, immediately plays the last bot message.
@@ -1012,11 +1127,14 @@ export default function ChatInterface() {
   }, [isLoading, speakerMode, preloadAudio, writeInput]);
 
   const handleSend = useCallback(() => {
+    // iOS: ignore Send while a voice clip is still recording or transcribing —
+    // the transcribed text isn't in the input yet, so there's nothing to send.
+    if (iosRecordActiveRef.current || isTranscribing) return;
     if (!session || !input.trim() || isLoading) return;
     // Tapping Send while recording: stop mic and send in one action
     if (isRecordingRef.current) stopRecording();
     sendMessage(input, messages, session);
-  }, [session, input, isLoading, messages, sendMessage, stopRecording]);
+  }, [session, input, isLoading, messages, sendMessage, stopRecording, isTranscribing]);
 
   // ── Translation ────────────────────────────────────────────────────────────
 
@@ -1413,19 +1531,37 @@ export default function ChatInterface() {
           {/* Mic — tap to start, tap to stop (does NOT auto-send on stop) */}
           <button
             onClick={handleVoiceInput}
-            title={isRecording ? 'Stop recording' : 'Record voice message'}
+            disabled={isTranscribing}
+            title={
+              isTranscribing
+                ? 'Transcribing…'
+                : isRecording
+                  ? 'Stop recording'
+                  : 'Record voice message'
+            }
             style={{
               flexShrink: 0, width: 44, height: 44, borderRadius: '50%', border: 'none',
-              cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center',
+              cursor: isTranscribing ? 'default' : 'pointer',
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
               transition: 'all 0.2s',
               ...(isRecording
                 ? { background: '#ef4444', color: C.white, boxShadow: '0 0 0 4px rgba(239,68,68,0.2)' }
                 : { background: '#f3f4f6', color: C.textMuted }),
             }}
           >
-            <span style={isRecording ? W : { color: C.textMuted }}>
-              {isRecording ? <IconMicStop /> : <IconMic />}
-            </span>
+            {isTranscribing ? (
+              <span
+                style={{
+                  width: 18, height: 18, borderRadius: '50%',
+                  border: `2px solid ${C.textMuted}`, borderTopColor: 'transparent',
+                  display: 'inline-block', animation: 'spin 0.8s linear infinite',
+                }}
+              />
+            ) : (
+              <span style={isRecording ? W : { color: C.textMuted }}>
+                {isRecording ? <IconMicStop /> : <IconMic />}
+              </span>
+            )}
           </button>
 
           {/* Text input — contentEditable <div> (not <input>) so mobile
@@ -1440,7 +1576,13 @@ export default function ChatInterface() {
             contentEditable={!isLoading}
             suppressContentEditableWarning
             aria-label="Type your message"
-            data-chat-placeholder={isRecording ? 'Listening... tap Send to stop & send' : 'Type your message...'}
+            data-chat-placeholder={
+              isTranscribing
+                ? 'Transcribing…'
+                : isRecording
+                  ? (isAppleMobile() ? 'Recording… tap the mic to stop' : 'Listening... tap Send to stop & send')
+                  : 'Type your message...'
+            }
             onInput={e => {
               const el = e.currentTarget as HTMLDivElement;
               const text = el.innerText;

--- a/src/components/Chat/SessionSetup.tsx
+++ b/src/components/Chat/SessionSetup.tsx
@@ -160,7 +160,14 @@ export default function SessionSetup({
                     cursor: isLoading ? "not-allowed" : "pointer",
                     border: `1.5px solid ${sel ? C.green : C.border}`,
                     borderRadius: 14,
-                    padding: "10px 8px",
+                    padding: "8px",
+                    // Equal height for every button so a 2-line label like
+                    // "Upper Intermediate" doesn't make its row taller than the
+                    // single-line rows (kept the grid asymmetric on iPhone).
+                    minHeight: 54,
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
                     textAlign: "center",
                     background: sel
                       ? `linear-gradient(135deg,${C.green},${C.greenDark})`


### PR DESCRIPTION
Fixes the two issues reported on iPhone.

## 1. iOS voice input not transcribing (PWA)
- The browser Web Speech API is unreliable inside iOS standalone PWAs — the first mic tap returned nothing.
- On **iPhone/iPad only**, voice input now records a short clip with `MediaRecorder` and transcribes it server-side via a new `/api/transcribe` route (OpenAI Whisper, reusing the same `OPENAI_API_KEY` as `/api/tts`).
- **Android/desktop keep the existing live Web Speech path unchanged** (no regression).
- UX: mic shows a spinner while transcribing; Send is ignored while recording/transcribing; transcript is appended to the input for the student to review before sending.
- Fails safe: if the key is missing or the request fails, the input is left as-is — the chat never crashes.

## 2. Asymmetric level grid on iPhone 13
- The 2-line "Upper Intermediate" label stretched its row taller than the others.
- Every level button now has an equal `min-height` with centered content, so all six are uniform.

## Verified locally
- tsc passes; `/chat` renders; `/api/transcribe` route resolves (503 without key, parses multipart with key).
- Level grid rendered from the real component — all buttons equal height.

## Test plan
- [ ] iPhone PWA: tap mic → speak → tap mic to stop → spinner → transcribed text appears in input → Send.
- [ ] Android/desktop: live voice input unchanged.
- [ ] Level picker: all six buttons same height on iPhone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)