### PR TITLE
fix(chat): symmetric level grid on narrow screens (iPhone SE)

### DIFF
--- a/src/components/Chat/SessionSetup.tsx
+++ b/src/components/Chat/SessionSetup.tsx
@@ -145,7 +145,11 @@ export default function SessionSetup({
           <div
             style={{
               display: "grid",
-              gridTemplateColumns: "repeat(3,1fr)",
+              // minmax(0,1fr) forces three exactly-equal columns. Plain "1fr"
+              // has a min-content floor, so on narrow screens (e.g. iPhone SE)
+              // a long word like "Intermediate" would widen its column and throw
+              // the whole grid out of alignment.
+              gridTemplateColumns: "repeat(3, minmax(0, 1fr))",
               gap: 8,
             }}
           >
@@ -181,8 +185,9 @@ export default function SessionSetup({
                   <div
                     style={{
                       fontWeight: 700,
-                      fontSize: 14,
+                      fontSize: 13,
                       lineHeight: 1.15,
+                      overflowWrap: "break-word",
                       ...(sel ? W : { color: C.textPrimary }),
                     }}
                   >


### PR DESCRIPTION
On narrow widths, repeat(3,1fr) let a long label (Intermediate) widen its column, breaking the 3-column alignment on iPhone SE. Switch to repeat(3, minmax(0,1fr)) for exactly-equal columns + 13px label so the longest labels fit on one line at 360px+. Verified symmetric at 375/360px (320px 1st-gen SE has only a tiny cosmetic touch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)